### PR TITLE
fix error due to an API change

### DIFF
--- a/assets/js/authentication.js
+++ b/assets/js/authentication.js
@@ -1,5 +1,8 @@
 // Get your own Spotify Client ID at https://developer.spotify.com/
-const AUTH_CLIENT_ID = '0e188cfad9f3470ca424b84c2dc532df';
+const DEFAULT_CLIENT_ID = '0e188cfad9f3470ca424b84c2dc532df'; // the original client ID
+const FORK_CLIENT_ID = '1e17f3a4f3ad4df79c8ee27c2cc32623'; // my client ID -- remove if PR is accepted, left in so I can host myself
+
+const AUTH_CLIENT_ID = DEFAULT_CLIENT_ID;
 const AUTH_MAX_RECENT_CONNECTION_AGE = 1000 * 60 * 60 * 24 * 7; // 7 days
 const AUTH_APPLICATION_SCOPES = [
     'playlist-modify-public',
@@ -85,6 +88,7 @@ function auth_connect_spotify() {
     // Build the required parameters for the Spotify OAuth page
     const integrity = auth_get_hash(60);
     const callback_uri = encodeURIComponent(location.origin + location.pathname);
+    alert(callback_uri)
     const scopes = encodeURIComponent(AUTH_APPLICATION_SCOPES);
 
     // Update the UI to show the user that they are connecting

--- a/assets/js/authentication.js
+++ b/assets/js/authentication.js
@@ -1,8 +1,5 @@
 // Get your own Spotify Client ID at https://developer.spotify.com/
-const DEFAULT_CLIENT_ID = '0e188cfad9f3470ca424b84c2dc532df'; // the original client ID
-const FORK_CLIENT_ID = '1e17f3a4f3ad4df79c8ee27c2cc32623'; // my client ID -- remove if PR is accepted, left in so I can host myself
-
-const AUTH_CLIENT_ID = DEFAULT_CLIENT_ID;
+const AUTH_CLIENT_ID = '0e188cfad9f3470ca424b84c2dc532df';
 const AUTH_MAX_RECENT_CONNECTION_AGE = 1000 * 60 * 60 * 24 * 7; // 7 days
 const AUTH_APPLICATION_SCOPES = [
     'playlist-modify-public',

--- a/assets/js/authentication.js
+++ b/assets/js/authentication.js
@@ -2,7 +2,7 @@
 const DEFAULT_CLIENT_ID = '0e188cfad9f3470ca424b84c2dc532df'; // the original client ID
 const FORK_CLIENT_ID = '1e17f3a4f3ad4df79c8ee27c2cc32623'; // my client ID -- remove if PR is accepted, left in so I can host myself
 
-const AUTH_CLIENT_ID = DEFAULT_CLIENT_ID;
+const AUTH_CLIENT_ID = FORK_CLIENT_ID;
 const AUTH_MAX_RECENT_CONNECTION_AGE = 1000 * 60 * 60 * 24 * 7; // 7 days
 const AUTH_APPLICATION_SCOPES = [
     'playlist-modify-public',
@@ -88,7 +88,6 @@ function auth_connect_spotify() {
     // Build the required parameters for the Spotify OAuth page
     const integrity = auth_get_hash(60);
     const callback_uri = encodeURIComponent(location.origin + location.pathname);
-    alert(callback_uri)
     const scopes = encodeURIComponent(AUTH_APPLICATION_SCOPES);
 
     // Update the UI to show the user that they are connecting

--- a/assets/js/authentication.js
+++ b/assets/js/authentication.js
@@ -2,7 +2,7 @@
 const DEFAULT_CLIENT_ID = '0e188cfad9f3470ca424b84c2dc532df'; // the original client ID
 const FORK_CLIENT_ID = '1e17f3a4f3ad4df79c8ee27c2cc32623'; // my client ID -- remove if PR is accepted, left in so I can host myself
 
-const AUTH_CLIENT_ID = FORK_CLIENT_ID;
+const AUTH_CLIENT_ID = DEFAULT_CLIENT_ID;
 const AUTH_MAX_RECENT_CONNECTION_AGE = 1000 * 60 * 60 * 24 * 7; // 7 days
 const AUTH_APPLICATION_SCOPES = [
     'playlist-modify-public',

--- a/assets/js/spotify.js
+++ b/assets/js/spotify.js
@@ -253,7 +253,9 @@ async function SpotifyAPI(token) {
 
         // Match the request's HTTP status code to one of the possible scenarios
         switch (response.status) {
-            case 204:
+            // Spotify has changed the return code from 204 to 200?
+            // I'll keep the dual case incase they decide to revert the change.
+            case 204: case 200:
                 return true;
             case 403:
                 return false;


### PR DESCRIPTION
Spotify changed the return code of /me/player/shuffle to 200 instead of 204. This caused spotify.js to return false, thus causing the shuffle error. Changing to `case 204: case 200:` fixed this issue and works perfectly fine.