### PR TITLE
Implemented caching etc

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -14,9 +14,6 @@ window.addEventListener('DOMContentLoaded', () => {
 	if (localStorage.getItem('shuffle_button_state') !== null) {
 		document.getElementById('alt-shuffle').checked = true;
 	}
-	if (localStorage.getItem('last_used_playlist_name') !== null) {
-		document.getElementById('choose_playlist').checked = true;
-	}
 });
 
 
@@ -55,7 +52,7 @@ async function shuffle_and_play() {
 	
 	if (cache_full_list) { //cache button pressed and local storage supported
 		if (localStorage.getItem('playlist_id') !== null && localStorage.getItem('playlist') !== null) {
-			cached_playlist_id = JSON.parse(localStorage.playlist_id);
+			cached_playlist_id = localStorage.playlist_id;
 			cached_playlist = JSON.parse(localStorage.playlist);
 			if (cached_playlist_id == playlist_id) {//check if selected playlist is same as cached one
 				//run here if cache is OK
@@ -99,7 +96,7 @@ async function shuffle_and_play() {
 	// Filter the retrieved songs to only include songs that are not local
 	songs = songs.filter((song) => !song.local);
 	if (cache_full_list) {
-		localStorage.setItem('playlist_id', JSON.stringify(playlist_id));
+		localStorage.setItem('playlist_id', playlist_id);
 		localStorage.setItem('playlist', JSON.stringify(songs));
 	}
 	
@@ -198,12 +195,12 @@ async function shuffle_and_play() {
             ui_render_play_button('Updating Temporary Playlist...', false);
 			console.log('shuffled playlist length = ' + uris.length);
 			await SPOTIFY_API.set_playlist_tracks(temporary.id, uris.splice(0,50));
-			await async_wait(1000);
+			await async_wait(500);
 			console.log('sleeping for second');
 			while (uris.length > 50) {
 				console.log('shuffled playlist length = ' + uris.length);
 				await SPOTIFY_API.add_playlist_tracks(temporary.id, uris.splice(0,50));
-				await async_wait(1000);
+				await async_wait(500);
 				console.log('sleeping for second');
 			}
 			if (uris !== 0) {
@@ -342,12 +339,12 @@ async function save_to_playlist() {
         ui_render_save_button('Updating Playlist...', false);
 		console.log('shuffled playlist length = ' + uris.length);
 		await SPOTIFY_API.set_playlist_tracks(playlist.id, uris.splice(0,50));
-		await async_wait(1000);
+		await async_wait(500);
 		console.log('sleeping for second');
 		while (uris.length > 50) {
 			console.log('shuffled playlist length = ' + uris.length);
 			await SPOTIFY_API.add_playlist_tracks(playlist.id, uris.splice(0,50));
-			await async_wait(1000);
+			await async_wait(500);
 			console.log('sleeping for second');
 		}
 		if (uris !== 0) {
@@ -519,6 +516,9 @@ async function load_application() {
     document.querySelector('.container').classList.add('authenticated');
     document.getElementById('application_section').setAttribute('style', '');
     document.getElementById('loader_container').setAttribute('style', 'display: none;');
+	if (localStorage.getItem('playlist_id') !== null) {
+		document.getElementById("choose_playlist").value = localStorage.playlist_id;
+	}
 }
 
 window.addEventListener('load', () => {

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -5,17 +5,17 @@ let RECENT_SPOTIFY_PLAYBACK_DEVICE_ID; // Caches the device id of the Spotify pl
 let RECENT_SPOTIFY_PLAYBACK_PLAYLIST_ID; // Caches the playlist id of the Spotify player that most recently played shuffled tracks
 let RECENT_SPOTIFY_SHUFFLED_TRACKS = []; // Caches the most recently shuffled tracks from Spotify
 const ARE_CREATED_PLAYLISTS_PUBLIC = false; // Determines whether created playlists are public or not by True Shuffle
-let IS_LOCAL_STORAGE_SUPPORTED = local_storage_supported();
 
 //set checkboxes from cache
 window.addEventListener('DOMContentLoaded', () => {
-	if (IS_LOCAL_STORAGE_SUPPORTED == true) {
-		if (localStorage.getItem('cache_button_state') !== null) {
-			document.getElementById('cache-full-list').checked = true;
-		}
-		if (localStorage.getItem('shuffle_button_state') !== null) {
-			document.getElementById('alt-shuffle').checked = true;
-		}
+	if (localStorage.getItem('cache_button_state') !== null) {
+		document.getElementById('cache-full-list').checked = true;
+	}
+	if (localStorage.getItem('shuffle_button_state') !== null) {
+		document.getElementById('alt-shuffle').checked = true;
+	}
+	if (localStorage.getItem('last_used_playlist_name') !== null) {
+		document.getElementById('choose_playlist').checked = true;
 	}
 });
 
@@ -53,7 +53,7 @@ async function shuffle_and_play() {
 	let cached_playlist;
 	let cache_state = false;
 	
-	if (cache_full_list && IS_LOCAL_STORAGE_SUPPORTED == true) { //cache button pressed and local storage supported
+	if (cache_full_list) { //cache button pressed and local storage supported
 		if (localStorage.getItem('playlist_id') !== null && localStorage.getItem('playlist') !== null) {
 			cached_playlist_id = JSON.parse(localStorage.playlist_id);
 			cached_playlist = JSON.parse(localStorage.playlist);
@@ -64,7 +64,7 @@ async function shuffle_and_play() {
 				localStorage.setItem('cache_button_state', 'True');
 			}
 		}		
-	} else if (IS_LOCAL_STORAGE_SUPPORTED == true) { //remove button state
+	} else { //remove button state
 		localStorage.removeItem('cache_button_state')
 	}
 	if (!cache_state) { //no cache
@@ -90,7 +90,7 @@ async function shuffle_and_play() {
 			alert('Failed to retrieve songs from Spotify. Refresh the page to try again.');
 			return console.log(error);
 		}
-		if (!cache_full_list && IS_LOCAL_STORAGE_SUPPORTED == true) {
+		if (!cache_full_list) {
 			localStorage.removeItem('playlist_id')
 			localStorage.removeItem('playlist')
 		}
@@ -98,7 +98,7 @@ async function shuffle_and_play() {
 	
 	// Filter the retrieved songs to only include songs that are not local
 	songs = songs.filter((song) => !song.local);
-	if (cache_full_list && IS_LOCAL_STORAGE_SUPPORTED == true) {
+	if (cache_full_list) {
 		localStorage.setItem('playlist_id', JSON.stringify(playlist_id));
 		localStorage.setItem('playlist', JSON.stringify(songs));
 	}
@@ -121,14 +121,10 @@ async function shuffle_and_play() {
     if (alt_shuffle) 
     {
         results = get_spread_batch_no_adjacent(shuffled, 200, size);
-		if (IS_LOCAL_STORAGE_SUPPORTED == true) {
-			localStorage.setItem('shuffle_button_state', 'True');
-		}
+		localStorage.setItem('shuffle_button_state', 'True');
     } else {
         results = get_spread_batch(shuffled, 200, size);
-		if (IS_LOCAL_STORAGE_SUPPORTED == true) {
-			localStorage.removeItem('shuffle_button_state')
-		}
+		localStorage.removeItem('shuffle_button_state')
     }
 
 	//results.forEach(element => console.log(element.added_by_id));

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -503,6 +503,14 @@ async function load_application() {
 
         // Render the devices in the UI selector
         document.getElementById('choose_playlist').innerHTML = rendered.join('\n');
+		if (localStorage.getItem('playlist_id') !== null) {
+			const playlistIds = Object.keys(playlists);
+			if (playlistIds.includes(localStorage.playlist_id)) {
+				document.getElementById('choose_playlist').value = localStorage.playlist_id;
+			} else {
+				console.log('saved playlist id does not exist anymore')
+			}
+		}
     } catch (error) {
         log('ERROR', 'Failed to retrieve Spotify playlists.');
         loading_message.innerText = 'Failed to retrieve Spotify playlists. Refresh the page to try again.';
@@ -516,9 +524,7 @@ async function load_application() {
     document.querySelector('.container').classList.add('authenticated');
     document.getElementById('application_section').setAttribute('style', '');
     document.getElementById('loader_container').setAttribute('style', 'display: none;');
-	if (localStorage.getItem('playlist_id') !== null) {
-		document.getElementById("choose_playlist").value = localStorage.playlist_id;
-	}
+
 }
 
 window.addEventListener('load', () => {

--- a/assets/js/spotify.js
+++ b/assets/js/spotify.js
@@ -323,6 +323,18 @@ async function SpotifyAPI(token) {
         });
     };
 
+    // Define the method for setting/updating a playlist's tracks
+    instance.add_playlist_tracks = async (playlist_id, track_uris) => {
+        // Make an API request to Spotify to update playlist's tracks
+        return await instance._api_request({
+            method: 'POST',
+            endpoint: `/playlists/${playlist_id}/tracks`,
+            body: JSON.stringify({
+                uris: track_uris,
+            }),
+        });
+    };
+
     // Retrieve the profile from Spotify to validate the provided token
     await instance.get_profile();
     return instance;

--- a/index.html
+++ b/index.html
@@ -93,6 +93,10 @@
                                 <input type="checkbox" id="alt-shuffle" name="alt-shuffle" value="True" />
                                 <label for="alt-shuffle">Do not repeat same songs across shuffles</label><br />
                             </div>
+                            <div class="col-lg-7 col-md-10 col-sm-12 m-auto mt-2">
+                                <input type="checkbox" id="cache-full-list" name="cache-full-list" value="True" />
+                                <label for="cache-full-list">Use browser cache for last used list</label><br />
+                            </div>
                         </div>
 
                         <div class="col-lg-7 col-md-10 col-sm-12 m-auto mt-2">


### PR DESCRIPTION
Added cache button to html
Made main.js cache last used playlist
Set shuffled tracks size back to 200
Added add tracks to spotify.js to be able to handle replacing tracks in batch
Added code for site to remember if checkboxes are checked and which playlist is last used
Made it not to show Shuffle Results for free users
Made site to remember which playlist was used last if it exists anymore

I do not have premium currently so i cannot test premium direct play feature

10000 songs takes about 3MB from localStorage
